### PR TITLE
remove lint from molecule and update tox envs

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -42,9 +42,6 @@ platforms:
     memory: 2048
 verifier:
   name: ansible
-lint: |
-  set -e
-  ansible-lint
 scenario:
   name: default
   create_sequence:
@@ -71,7 +68,6 @@ scenario:
     - destroy
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-minversion = 3.20
+minversion = 4.0.2
+requires =
+  tox>=4.0.2
 envlist =
   devel
-  py310-ansible{6,7,devel}
-  py311-ansible{6,7,devel}
+  py310-ansible{6,7,8,devel}
+  py311-ansible{6,7,8,devel}
 skipsdist = true
 
 [testenv:devel]
@@ -11,22 +13,23 @@ passenv = *
 basepython = python3.10
 deps =
     git+https://github.com/ansible-community/ansible-lint.git
-    git+https://github.com/ansible-community/molecule.git
-    git+https://github.com/ansible-community/molecule-vagrant.git
-    git+https://github.com/pycontribs/python-vagrant.git
+    molecule-plugins[vagrant]@git+https://github.com/ansible-community/molecule-plugins.git
     https://github.com/ansible/ansible/archive/devel.tar.gz
+    ansible-compat <= 4.0.0
 commands =
+    ansible-lint
     molecule test
 
 [testenv]
 passenv = *
 deps =
     ansible6: ansible==6.7
-    ansible7: ansible==7.2
+    ansible7: ansible==7.5
+    ansible8: ansible==8.0.0a2
+    ansible-compat <= 4.0.0
     ansibledevel: https://github.com/ansible/ansible/archive/devel.tar.gz
     ansible-lint
-    molecule
-    molecule-vagrant
-    python-vagrant
+    molecule-plugins[vagrant]
 commands =
+    ansible-lint
     molecule test


### PR DESCRIPTION
`ansible-compat <= 4.0.0` is due to https://github.com/ansible-community/molecule/issues/3903